### PR TITLE
improve performance of `indexes`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Drop Python 2 support.
 
 Drop Python 3.5 support and tag Python 3.9 support.
 
+Add ``indexes_optimized`` for faster iteration over bitset members.
+
 
 Version 0.7.16
 --------------

--- a/bitsets/bases.py
+++ b/bitsets/bases.py
@@ -20,7 +20,7 @@ class MemberBits(int, metaclass=meta.MemberBitsMeta):
         bits: String with the binary membership representation.
     """
 
-    _indexes = integers.indexes
+    _indexes = integers.indexes_optimized
 
     _reinverted = integers.reinverted
 

--- a/bitsets/integers.py
+++ b/bitsets/integers.py
@@ -13,12 +13,9 @@ def indexes(n):
     >>> [tuple(indexes(i)) for i in range(8)]
     [(), (0,), (1,), (0, 1), (2,), (0, 2), (1, 2), (0, 1, 2)]
     """
-    i = 0
-    while n:
-        if n & 1:
+    for i, b in enumerate(bin(n)[-1:1:-1]):
+        if b == '1':
             yield i
-        i += 1
-        n >>= 1
 
 
 def n(indexes):

--- a/bitsets/integers.py
+++ b/bitsets/integers.py
@@ -13,7 +13,22 @@ def indexes(n):
     >>> [tuple(indexes(i)) for i in range(8)]
     [(), (0,), (1,), (0, 1), (2,), (0, 2), (1, 2), (0, 1, 2)]
     """
-    for i, b in enumerate(bin(n)[-1:1:-1]):
+    i = 0
+    while n:
+        if n & 1:
+            yield i
+        i += 1
+        n >>= 1
+
+
+def indexes_optimized(n):
+    """Yield index sets unranking n in colexicographical order. Faster version
+    of ``indexes``.
+
+    >>> [tuple(indexes_optimized(i)) for i in range(8)]
+    [(), (0,), (1,), (0, 1), (2,), (0, 2), (1, 2), (0, 1, 2)]
+    """
+    for i, b in enumerate(bin(n)[:1:-1]):
         if b == '1':
             yield i
 


### PR DESCRIPTION
Hi, just tried this neat project and it nicely solved some memory problems I was having with giant sets, however ``indexes`` became a bit of a hot spot. The following is a performance tweak for that function, which seems to be better for both small and large integers:

```python
def indexes(n):
    i = 0
    while n:
        if n & 1:
            yield i
        i += 1
        n >>= 1

def indexes_new(n):
    for i, b in enumerate(bin(n)[-1:1:-1]):
        if b == '1':
            yield i

n = 401247

%%timeit
tuple(indexes(n))
# 3.12 µs ± 31.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%%timeit
tuple(indexes_new(n))
# 1.85 µs ± 16.8 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

n = 49571049247102492471029471029473836150147123059127451024974774770129471029471092470129381410293414012345970273

%%timeit
tuple(indexes(n))
# 57.6 µs ± 890 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%%timeit
tuple(indexes_new(n))
# 23.7 µs ± 112 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Edit - I just check some 'sparse' bits (e.g. `1 << 200 | 1 << 100`) and the story is similar.